### PR TITLE
redundant cancel test

### DIFF
--- a/.github/workflows/cancel_redundantbuild.yml
+++ b/.github/workflows/cancel_redundantbuild.yml
@@ -1,5 +1,5 @@
 name: cancel redundant build
-on: push
+on: [push, pull_request]
 
 jobs:
   cancel:

--- a/.github/workflows/cancel_redundantbuild.yml
+++ b/.github/workflows/cancel_redundantbuild.yml
@@ -5,6 +5,7 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
+      # no check for master and tag
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
         if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
         env:

--- a/.github/workflows/cancel_redundantbuild.yml
+++ b/.github/workflows/cancel_redundantbuild.yml
@@ -1,4 +1,6 @@
 name: cancel redundant build
+# when pull_request, both push and pull_request (synchronize) will trigger.
+# this action sample will prevent duplicate run, but run only 1 of them.
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/push_and_pr.yml
+++ b/.github/workflows/push_and_pr.yml
@@ -1,0 +1,9 @@
+name: push and pull_request
+
+on: [push, pull_request]
+
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo push and pull_request trigger


### PR DESCRIPTION
should be cancel for actions triggered by push on pull_request.

only single build run is expected.

## normal

![image](https://user-images.githubusercontent.com/3856350/80328688-01c0f800-887b-11ea-8c24-c3e69ff82cd9.png)

## redundant cancel

duplicate run will

![image](https://user-images.githubusercontent.com/3856350/80328549-9d059d80-887a-11ea-8d98-1c9206782a0b.png)

cancel by latest action

![image](https://user-images.githubusercontent.com/3856350/80328716-169d8b80-887b-11ea-987f-7dd9f54fd3b0.png)
